### PR TITLE
eclass-to-manpage.awk: Format author list with explicit line breaks

### DIFF
--- a/eclass-to-manpage.awk
+++ b/eclass-to-manpage.awk
@@ -1,5 +1,5 @@
 #!/usr/bin/awk -f
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This awk converts the comment documentation found in eclasses
@@ -171,7 +171,8 @@ function handle_eclass() {
 	print ".\\\" See eclass-to-manpage.awk for documentation on how to get"
 	print ".\\\" your eclass nicely documented as well."
 	print ".\\\""
-	print ".TH \"" toupper(eclass) "\" 5 \"" strftime("%b %Y") "\" \"Portage\" \"portage\""
+	print ".TH \"" toupper(eclass) "\" 5 \"" strftime("%b %Y") "\"" \
+		" \"Gentoo Linux\" \"eclass-manpages\""
 
 	# now eat the global data
 	getline

--- a/eclass-to-manpage.awk
+++ b/eclass-to-manpage.awk
@@ -139,7 +139,7 @@ function eat_paragraph() {
 }
 
 function pre_text(p) {
-	return ".nf\n" p "\n.fi"
+	return gensub(/\n/, "\n.br\n", "g", p)
 }
 
 function man_text(p) {
@@ -408,7 +408,8 @@ function handle_footer() {
 	print ".BR " eclass
 	print ".SH \"SEE ALSO\""
 	print ".BR ebuild (5)"
-	print pre_text(gensub("@ECLASS@", eclass, 1, vcs_url))
+	print ".br"
+	print gensub("@ECLASS@", eclass, 1, vcs_url)
 }
 
 #


### PR DESCRIPTION
An .nf/.fi pair causes man2html to render the text as a preformatted block in teletype font.
See https://devmanual.gentoo.org/eclass-reference/elisp.eclass/index.html#lbAG for an example how it looks like.

Use explicit .br breaks instead to work around this.
