### PR TITLE
Makefile: prevent infinite recursion when no eclasses in ECLASSDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ SCRIPT = eclass-to-manpage.awk
 ECLASSDIR = .
 ECLASSES = $(sort $(wildcard ${ECLASSDIR}/*.eclass))
 
+ifeq ($(ECLASSES),)
+$(error ERROR: No eclass files found. Is ECLASSDIR "${ECLASSDIR}" valid?)
+endif
+
 OUTDIR = .
 MANPAGES = $(sort $(patsubst ${ECLASSDIR}/%,${OUTDIR}/%.5,${ECLASSES}))
 ERRFILES = $(sort $(patsubst ${ECLASSDIR}/%,${OUTDIR}/%.5.err,${ECLASSES}))


### PR DESCRIPTION
Invoking 'make' on a freshly cleaned repository causes an infinite recursion cause ECLASSES is empty since there are no eclasses in ECLASSDIR.

Instead we now bail out early with an hopefully helpful error message.