### PR TITLE
Tighten regex for default var="val" extraction

### DIFF
--- a/eclass-to-manpage.awk
+++ b/eclass-to-manpage.awk
@@ -363,7 +363,7 @@ function _handle_variable() {
 	# extract the default variable value
 	# first try var="val"
 	op = "="
-	regex = "^.*" var_name "=(.*)$"
+	regex = "^[^:]*" var_name "=(.*)$"
 	val = gensub(regex, "\\1", 1, $0)
 	if (val == $0) {
 		# next try : ${var:=val}


### PR DESCRIPTION
The current regex causes false positive matches for lines like : "${var=val}"
where it will extract 'val}"' instead of 'val' as the value.

Seen with nginx.eclass, commit 75c2cb66eed1 in the gentoo repo.